### PR TITLE
Enhance Money.Scan to support JSON input

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -89,6 +89,18 @@ func TestMoney_Scan(t *testing.T) {
 			src:     "a|b|c",
 			wantErr: true,
 		},
+		{
+			src:  `{"amount": 10, "currency": "CAD"}`,
+			want: New(10, CAD),
+		},
+		{
+			src:  []byte(`{"amount": 10, "currency": "USD"}`),
+			want: New(10, USD),
+		},
+		{
+			src:  "{}",
+			want: &Money{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%#v", tt.src), func(t *testing.T) {
@@ -105,13 +117,12 @@ func TestMoney_Scan(t *testing.T) {
 			if tt.wantErr {
 				return
 			}
-			if got == nil {
-				t.Errorf("money.Scan() result was <nil>")
+			if *tt.want == *got {
 				return
 			}
 			eq, err := tt.want.Equals(got)
 			if err != nil {
-				t.Errorf(err.Error())
+				t.Error(err)
 			}
 			if !eq {
 				t.Errorf("Value() got = %s %s, want %s %s", got.Display(), got.Currency().Code, tt.want.Display(), tt.want.Currency().Code)


### PR DESCRIPTION
## Summary by Sourcery

Enhance Money.Scan to accept and unmarshal JSON payloads, streamline type assertions and error messages, and extend tests to cover the new JSON behavior.

New Features:
- Support JSON input for Money.Scan from string and []byte sources.

Enhancements:
- Refactor type switches and simplify error formatting in Money.Scan and Currency.Scan.

Tests:
- Add TestMoney_Scan cases for JSON object and empty JSON inputs.
- Simplify test assertion logic and error reporting in TestMoney_Scan.